### PR TITLE
Fix error with pre-commit package interactions with Husky

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,0 @@
-repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v2.3.0"
-    hooks:
-    - id: check-yaml
-    - id: end-of-file-fixer
-    - id: trailing-whitespace

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,8 +1,11 @@
 {
-  "trailingComma": "es5",
-  "semi": true,
   "tabWidth": 2,
-  "singleQuote": false,
-  "jsxSingleQuote": false,
-  "plugins": ["prettier-plugin-tailwindcss"]
+  "useTabs": false,
+  "singleQuote": true,
+  "semi": true,
+  "bracketSpacing": true,
+  "arrowParens": "avoid",
+  "trailingComma": "es5",
+  "bracketSameLine": true,
+  "printWidth": 80
 }

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "*.{ts, html}": [
       "eslint --fix"
     ],
-    "*.{json,css,scss,less,md,ts,html,js}": [
+    "*.{json,css,scss,less,md,ts,html}": [
       "prettier --write"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -95,9 +95,11 @@
     "typescript": "^5"
   },
   "lint-staged": {
-    "**/*": [
-      "eslint --fix",
-      "prettier --write --ignore-unknown"
+    "*.{ts, html}": [
+      "eslint --fix"
+    ],
+    "*.{json,css,scss,less,md,ts,html,js}": [
+      "prettier --write"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "prepare": "husky && pip install pre-commit && git config --unset-all core.hooksPath && pre-commit install"
+    "prepare": "husky"
   },
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^6.5.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-pre-commit

--- a/test.js
+++ b/test.js
@@ -1,0 +1,1 @@
+console.log('test');

--- a/test.js
+++ b/test.js
@@ -1,1 +1,0 @@
-console.log('test');


### PR DESCRIPTION
<details>
<summary>Release notes</summary>
<ul>
<li>Updated Prettier settings</li>
<li>Remove pre-commit package</li>
<li>Update prepare run command</li>
</ul>
</details>

<p>
There was a bug with how the pre-commit package was interacting with the pre-commit hooks from Husky. The pre-commit package has been removed, and now any committed files should be properly put through Prettier and ESLint and formatted/updated.

You no longer need to run `npm run prepare`, it should run automatically after your initial `npm install` command.
</p>