### PR TITLE
Revert "Update eslint to 9"

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@types/react-dom": "^18",
     "@vitejs/plugin-react": "^4.2.1",
     "autoprefixer": "^10.4.17",
-    "eslint": "^9",
+    "eslint": "^8",
     "eslint-config-next": "14.2.3",
     "husky": "^9.0.11",
     "lint-staged": "^15.2.2",


### PR DESCRIPTION
Reverts Vero-Ventures/business-charter#19

Requesting to revert ESLint back to version ^8 because there seems to be an incompatibility with the Typescript-ESLint package.
More information [here](https://www.reddit.com/r/typescript/comments/1cjbjis/eslint_9_doesnt_work_with_typescript/).